### PR TITLE
メッセージ一覧画面の自動更新機能追加

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -82,6 +82,16 @@ $(function() {
       dataType: 'json',
       data: {id: last_message_id}
     })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message);
+        });
+        $('.chat-main__message-list').append(insertHTML);
+        $('.chat-main__message-list').animate({scrollTop: $('.chat-main__message-list')[0].scrollHeight});
+      }
+    })
   }
 
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -92,6 +92,9 @@ $(function() {
         $('.chat-main__message-list').animate({scrollTop: $('.chat-main__message-list')[0].scrollHeight});
       }
     })
+    .fail(function() {
+      alert('error');
+    });
   }
 
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function() {
 
   // 関数定義
   function templateHTML(message){
-    var template_html= `<div class="chat-main__message-list__message-box">
+    var template_html= `<div class="chat-main__message-list__message-box" data-message-id="${message.id}">
                           <div class="chat-main__message-list__message-box__info">
                             <div class="chat-main__message-list__message-box__info__member-name">
                               ${message.user_name}

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -76,6 +76,12 @@ $(function() {
 
   var reloadMessages = function() {
     var last_message_id = $('.chat-main__message-list__message-box:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
   }
 
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -75,6 +75,7 @@ $(function() {
   })
 
   var reloadMessages = function() {
+    var last_message_id = $('.chat-main__message-list__message-box:last').data("message-id");
   }
 
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -73,4 +73,8 @@ $(function() {
       resetSubmit();
     })
   })
+
+  var reloadMessages = function() {
+  }
+
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -97,4 +97,7 @@ $(function() {
     });
   }
 
+  if (document.location.href.match(/\/groups\/\d+\/messages/)){
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,2 @@
+class Api::MessagesController < ApplicationController
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,2 +1,7 @@
 class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.chat-main__message-list__message-box
+%div.chat-main__message-list__message-box{data: {message: {id: message.id}}}
   .chat-main__message-list__message-box__info
     .chat-main__message-list__message-box__info__member-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.content @message.content
 json.image @message.image_url
 json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
メッセージ一覧画面で自動更新を行えるようにする。
messagesのAPIコントローラを作成し、indexアクションを定義する。
groupsにネストさせてルーティングを設定し、jbuilderを使用してJSON形式でmessages.jsにデータを返す。
messages.jsに自動更新の処理を行う関数を定義し、
一定間隔で呼び出し、新しいメッセージが存在する場合非同期通信でhtmlを書き換える。

[![Image from Gyazo](https://i.gyazo.com/f8423466b23821cd93067b73109932bc.gif)](https://gyazo.com/f8423466b23821cd93067b73109932bc)
# Why
送信者のみ非同期通信が行えていましたがこの機能を追加することで自分以外からのメッセージもブラウザの更新無しで表示させることができ、ユーザーがより快適にコミュニケーションを取ることができるようになるため。
